### PR TITLE
Font-related fixes (...)

### DIFF
--- a/gcwconnect.py
+++ b/gcwconnect.py
@@ -85,8 +85,15 @@ surface.fill(colors["darkbg"])
 pygame.mouse.set_visible(False)
 pygame.key.set_repeat(199,69) #(delay,interval)
 
-font_path = os.path.join(datadir, 'Inconsolata.otf')
-font12 = pygame.font.Font(font_path, 12)
+## Fonts
+font_path   = '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf'
+font_tiny   = pygame.font.Font(font_path, 8)
+font_small  = pygame.font.Font(font_path, 10)
+font_medium = pygame.font.Font(font_path, 12)
+font_large  = pygame.font.Font(font_path, 16)
+font_huge   = pygame.font.Font(font_path, 54)
+gcw_font        = pygame.font.Font(os.path.join(datadir, 'gcwzero.ttf'), 25)
+font_mono_small = pygame.font.Font(os.path.join(datadir, 'Inconsolata.otf'), 14)
 
 ## File management
 def createpaths(): # Create paths, if necessary
@@ -287,14 +294,14 @@ class hint:
 				pygame.draw.rect(surface, colors["black"], (self.x+11, self.y+6, 10, 5))
 
 			button = pygame.draw.rect(surface, colors["black"], (self.x, self.y, 15, 11))
-			text = pygame.font.SysFont(None, 12).render(self.button.upper(), True, colors["white"], colors["black"])
+			text = font_tiny.render(self.button.upper(), True, colors["white"], colors["black"])
 			buttontext = text.get_rect()
 			buttontext.center = button.center
 			surface.blit(text, buttontext)
 
 		if self.button == "select" or self.button == "start":
-			lbox = aafilledcircle(surface, colors["black"], (self.x+5, self.y+4), 5)
-			rbox = aafilledcircle(surface, colors["black"], (self.x+29, self.y+4), 5)
+			lbox = aafilledcircle(surface, colors["black"], (self.x+5, self.y+5), 6)
+			rbox = aafilledcircle(surface, colors["black"], (self.x+29, self.y+5), 6)
 			straightbox = lbox.union(rbox)
 			buttoncenter = straightbox.center
 			if self.button == 'select':
@@ -306,14 +313,14 @@ class hint:
 			if self.button == 'start':
 				roundedbox.bottomleft = lbox.midbottom
 			pygame.draw.rect(surface, colors["black"], roundedbox)
-			text = pygame.font.SysFont(None, 11).render(self.button.upper(), True, colors["white"], colors["black"])
+			text = font_tiny.render(self.button.upper(), True, colors["white"], colors["black"])
 			buttontext = text.get_rect()
 			buttontext.center = buttoncenter
 			buttontext.move_ip(0, 1)
 			surface.blit(text, buttontext)
 
 			labelblock = pygame.draw.rect(surface, self.bg, (self.x+40,self.y,25,14))
-			labeltext = pygame.font.SysFont(None, 12).render(self.text, True, colors["white"], self.bg)
+			labeltext = font_tiny.render(self.text, True, colors["white"], self.bg)
 			surface.blit(labeltext, labelblock)
 
 		elif self.button in ('a', 'b', 'x', 'y'):
@@ -327,14 +334,13 @@ class hint:
 				color = colors["yellow"]
 
 			labelblock = pygame.draw.rect(surface, self.bg, (self.x+10,self.y,35,14))
-			labeltext = pygame.font.SysFont(None, 12).render(self.text, True, colors["white"], self.bg)
+			labeltext = font_tiny.render(self.text, True, colors["white"], self.bg)
 			surface.blit(labeltext, labelblock)
 
-			button = aafilledcircle(surface, color, (self.x,self.y+4), 5) # (x, y)
-			text = pygame.font.SysFont(None, 11).render(self.button.upper(), True, colors["white"], color)
+			button = aafilledcircle(surface, color, (self.x,self.y+5), 6) # (x, y)
+			text = font_tiny.render(self.button.upper(), True, colors["white"], color)
 			buttontext = text.get_rect()
 			buttontext.center = button.center
-			buttontext.move_ip(0, 1)
 			surface.blit(text, buttontext)
 
 		elif self.button in ('left', 'right', 'up', 'down'):
@@ -357,14 +363,13 @@ class hint:
 				pygame.draw.rect(surface, colors["white"], (self.x+6, self.y+7, 2, 3))
 
 			labelblock = pygame.draw.rect(surface, self.bg, (self.x+20,self.y,35,14))
-			labeltext = pygame.font.SysFont(None, 12).render(self.text, True, (255, 255, 255), self.bg)
+			labeltext = font_tiny.render(self.text, True, (255, 255, 255), self.bg)
 			surface.blit(labeltext, labelblock)
 
 class LogoBar(object):
 	'''The logo area at the top of the screen.'''
 
 	def __init__(self):
-		gcw_font = pygame.font.Font(os.path.join(datadir, 'gcwzero.ttf'), 25)
 		self.text1 = gcw_font.render('GCW', True, colors['logogcw'], colors['lightbg'])
 		self.text2 = gcw_font.render('CONNECT', True, colors['logoconnect'], colors['lightbg'])
 
@@ -384,9 +389,9 @@ def drawstatusbar(): # Set up the status bar
 	global colors
 	pygame.draw.rect(surface, colors['lightbg'], (0,224,320,16))
 	pygame.draw.line(surface, colors['white'], (0, 223), (320, 223))
-	wlantext = pygame.font.SysFont(None, 16).render("...", True, colors['white'], colors['lightbg'])
+	wlantext = font_mono_small.render("...", True, colors['white'], colors['lightbg'])
 	wlan_text = wlantext.get_rect()
-	wlan_text.topleft = (4, 227)
+	wlan_text.topleft = (2, 225)
 	surface.blit(wlantext, wlan_text)
 
 def drawinterfacestatus(): # Interface status badge
@@ -397,22 +402,24 @@ def drawinterfacestatus(): # Interface status badge
 	else:
 		wlanstatus = getcurrentssid(wlan)
 
-	wlantext = pygame.font.SysFont(None, 16).render(wlanstatus, True, colors['white'], colors['lightbg'])
+	wlantext = font_mono_small.render(wlanstatus, True, colors['white'], colors['lightbg'])
 	wlan_text = wlantext.get_rect()
-	wlan_text.topleft = (4, 227)
+	wlan_text.topleft = (2, 225)
 	surface.blit(wlantext, wlan_text)
 
+	# Note that the leading space here is intentional, to more cleanly overdraw any overly-long
+	# strings written to the screen beneath it (i.e. a very long ESSID)
 	if checkinterfacestatus(wlan):
-		text = pygame.font.SysFont(None, 16).render(" "+getip(wlan), True, colors['activeselbg'], colors['lightbg'])
+		text = font_mono_small.render(" "+getip(wlan), True, colors['white'], colors['lightbg'])
 		interfacestatus_text = text.get_rect()
-		interfacestatus_text.topright = (315, 227)
+		interfacestatus_text.topright = (317, 225)
 		surface.blit(text, interfacestatus_text)
 	else:
 		mac = mac_addresses.get(wlan)  # grabbed by enableiface()
 		if mac is not None:
-			text = pygame.font.SysFont(None, 16).render(" "+mac, True, colors['white'], colors['lightbg'])
+			text = font_mono_small.render(" "+mac, True, colors['white'], colors['lightbg'])
 			interfacestatus_text = text.get_rect()
-			interfacestatus_text.topright = (315, 227)
+			interfacestatus_text.topright = (317, 225)
 			surface.blit(text, interfacestatus_text)
 
 def redraw():
@@ -442,7 +449,7 @@ def modal(text, wait=False, timeout=False, query=False):
 	dialog = pygame.draw.rect(surface, colors['lightbg'], (64,88,192,72))
 	pygame.draw.rect(surface, colors['white'], (62,86,194,74), 2)
 
-	text = pygame.font.SysFont(None, 16).render(text, True, colors['white'], colors['lightbg'])
+	text = font_medium.render(text, True, colors['white'], colors['lightbg'])
 	modal_text = text.get_rect()
 	modal_text.center = dialog.center
 
@@ -578,9 +585,10 @@ class key:
 		if len(self.key) > 1:
 			key_width = 36
 		keybox = pygame.draw.rect(surface, colors['lightbg'], (left,top,key_width,key_height))
-		text = pygame.font.SysFont(None, 16).render(self.key, True, colors['white'], colors['lightbg'])
+		text = font_medium.render(self.key, True, colors['white'], colors['lightbg'])
 		label = text.get_rect()
 		label.center = keybox.center
+		label.y -= 1
 		surface.blit(text, label)
 
 class radio:
@@ -609,7 +617,7 @@ class radio:
 			key_width = 64
 		radiobutton = aafilledcircle(surface, colors['white'], (left, top), 8)
 		aafilledcircle(surface, colors['darkbg'], (left, top), 6)
-		text = pygame.font.SysFont(None, 16).render(self.key, True, (255, 255, 255), colors['darkbg'])
+		text = font_medium.render(self.key, True, (255, 255, 255), colors['darkbg'])
 		label = text.get_rect()
 		label.left = radiobutton.right + 8
 		label.top = radiobutton.top + 4
@@ -627,7 +635,7 @@ def getSSID():
 def drawEncryptionType():
 	global colors
 	# Draw top background
-	pygame.draw.rect(surface, colors['darkbg'], (0,40,320,140))
+	pygame.draw.rect(surface, colors['darkbg'], (0,40,320,200))
 
 	# Draw footer
 	pygame.draw.rect(surface, colors['lightbg'], (0,224,320,16))
@@ -655,7 +663,7 @@ def displayencryptionhint():
 
 	try:
 		if encryption:
-			pygame.draw.rect(surface, colors['darkbg'], (2,100,320,34))
+			pygame.draw.rect(surface, colors['darkbg'], (0,100,320,34))
 			hint("l", "L", 16, 113)
 			hint("r", "R", 289, 113)
 
@@ -666,7 +674,7 @@ def displayencryptionhint():
 				if enc == encryption:
 					# Draw a selection rectangle for the active encryption method
 					pygame.draw.rect(surface, colors['activeselbg'], labelblock)
-				labeltext = font12.render(enc.center(10, ' '), True, colors["white"])
+				labeltext = font_small.render(enc.center(10, ' '), True, colors["white"])
 				surface.blit(labeltext, labelblock)
 				pos += 1
 			pygame.display.update()
@@ -849,7 +857,7 @@ def displayinputlabel(kind, size=24): # Display passphrase on screen
 		# Draw SSID and encryption type labels
 		pygame.draw.rect(surface, colors['darkbg'], (2,100,320,34))
 		labelblock = pygame.draw.rect(surface, colors['white'], (0,35,320,20))
-		labeltext = pygame.font.SysFont(None, 18).render("Enter new SSID", True, colors['lightbg'], colors['white'])
+		labeltext = font_large.render("Enter new SSID", True, colors['lightbg'], colors['white'])
 		label = labeltext.get_rect()
 		label.center = labelblock.center
 		surface.blit(labeltext, label)
@@ -859,9 +867,9 @@ def displayinputlabel(kind, size=24): # Display passphrase on screen
 		# Draw SSID and encryption type labels
 		labelblock = pygame.draw.rect(surface, colors['white'], (0,35,320,20))
 		if len(ssid) >= 13:
-			labeltext = font12.render("Enter "+encryption+" for "+"%s..."%(ssid[:13]), True, colors['lightbg'], colors['white'])
+			labeltext = font_small.render("Enter "+encryption+" for "+"%s..."%(ssid[:13]), True, colors['lightbg'], colors['white'])
 		else:
-			labeltext = font12.render("Enter "+encryption+" key for "+ssid, True, colors['lightbg'], colors['white'])
+			labeltext = font_small.render("Enter "+encryption+" key for "+ssid, True, colors['lightbg'], colors['white'])
 		label = labeltext.get_rect()
 		label.center = labelblock.center
 		surface.blit(labeltext, label)
@@ -872,7 +880,7 @@ def displayinputlabel(kind, size=24): # Display passphrase on screen
 	text = "[ "
 	text += passphrase
 	text += " ]"
-	pw = pygame.font.SysFont(None, size).render(text, True, (0, 0, 0), colors['white'])
+	pw = font_mono_small.render(text, True, (0, 0, 0), colors['white'])
 	pwtext = pw.get_rect()
 	pwtext.center = bg.center
 	surface.blit(pw, pwtext)
@@ -960,7 +968,7 @@ def selectkey(keyboard, kind, direction=""):
 
 class Menu:
 	global colors
-	font = pygame.font.SysFont
+	font = font_medium
 	dest_surface = surface
 	canvas_color = colors["darkbg"]
 
@@ -974,7 +982,7 @@ class Menu:
 		self.menu_height = 0
 		self.selection_color = colors["activeselbg"]
 		self.text_color = colors["activetext"]
-		self.font = pygame.font.Font(font_path, 16)
+		self.font = font_medium
 
 	def move_menu(self, top, left):
 		self.origin = (top, left)
@@ -997,6 +1005,9 @@ class Menu:
 		self.dest_surface = dest_surface
 
 	def draw(self,move=0):
+		# Clear any old text (like from apinfo()), but don't overwrite button hint area above statusbar
+		pygame.draw.rect(surface, colors['darkbg'], (0,34,320,174))
+
 		if len(self.elements) == 0:
 			return
 
@@ -1075,7 +1086,7 @@ class NetworksMenu(Menu):
 
 	def get_item_height(self, element):
 		render = self.font.render(element[0], 1, self.text_color)
-		spacing = 5
+		spacing = 6
 		return (render.get_rect().height + spacing * 2) + 5
 
 	def render_element(self, menu_surface, element, left, top):
@@ -1124,22 +1135,20 @@ class NetworksMenu(Menu):
 		qual_img = pygame.image.load((os.path.join(datadir, signal_icon))).convert_alpha()
 		enc_img = pygame.image.load((os.path.join(datadir, enc_icon))).convert_alpha()
 
-		boldtext = pygame.font.Font(font_path, 16)
-		subtext = font12
-
-		ssid = boldtext.render(the_ssid, 1, self.text_color)
-		enc = subtext.render(enc_type, 1, colors["lightgrey"])
-		strength = subtext.render(str(str(percent) + "%").rjust(4), 1, colors["lightgrey"])
-		qual = subtext.render(element[1], 1, colors["lightgrey"])
+		ssid = font_mono_small.render(the_ssid, 1, self.text_color)
+		enc = font_small.render(enc_type, 1, colors["lightgrey"])
+		#strength = font_small.render(str(str(percent) + "%").rjust(4), 1, colors["lightgrey"])
+		#qual = font_small.render(element[1], 1, colors["lightgrey"])
 		spacing = 2
 
-		menu_surface.blit(ssid, (left + spacing, top, ssid.get_rect().width, ssid.get_rect().height))
-		menu_surface.blit(enc, (left + enc_img.get_rect().width + 12, top + 18, enc.get_rect().width, enc.get_rect().height))
-		menu_surface.blit(enc_img, pygame.rect.Rect(left + 8, (top + 24) - (enc_img.get_rect().height / 2), enc_img.get_rect().width, enc_img.get_rect().height))
+		menu_surface.blit(ssid, (left + spacing, top))
+		menu_surface.blit(enc, (left + enc_img.get_rect().width + 12, top + 18))
+		menu_surface.blit(enc_img, (left + 8, (top + 24) - (enc_img.get_rect().height / 2)))
 		# menu_surface.blit(strength, (left + 137, top + 18, strength.get_rect().width, strength.get_rect().height))
-		# menu_surface.blit(qual_img, pygame.rect.Rect(left + 140, top + 2, qual_img.get_rect().width, qual_img.get_rect().height))
-		menu_surface.blit(qual_img, pygame.rect.Rect(left + 140, top + 8, qual_img.get_rect().width, qual_img.get_rect().height))
-		pygame.display.flip()
+		qual_x = left + 200 - qual_img.get_rect().width - 3
+		qual_y = top + 7
+		menu_surface.blit(qual_img, (qual_x, qual_y))
+		pygame.display.update()
 
 	def draw(self,move=0):
 		if len(self.elements) == 0:
@@ -1163,8 +1172,7 @@ class NetworksMenu(Menu):
 			visible_elements = self.elements[self.selected_item - 2:self.selected_item + 3]
 			selected_within_visible = 2
 
-		# What width does everything have?
-		max_width = max([self.get_item_width(visible_element) for visible_element in visible_elements])
+		max_width = 320 - self.origin[0] - 3
 
 		# And now the height
 		heights = [self.get_item_height(visible_element) for visible_element in visible_elements]
@@ -1203,7 +1211,7 @@ def to_menu(new_menu):
 
 wirelessmenu = None
 menu = Menu()
-menu.move_menu(8, 41)
+menu.move_menu(3, 41)
 
 def mainmenu():
 	global wlan
@@ -1236,31 +1244,28 @@ def apinfo():
 		mac = file.read().strip('\n').replace(":", "")
 		file.close()
 		if mac == ap:
-			font18 = pygame.font.Font(font_path, 18)
-			font64 = pygame.font.Font(font_path, 64)
-
 			ssidlabel = "SSID"
-			renderedssidlabel = font64.render(ssidlabel, True, colors["lightbg"], colors["darkbg"])
+			renderedssidlabel = font_huge.render(ssidlabel, True, colors["lightbg"], colors["darkbg"])
 			ssidlabelelement = renderedssidlabel.get_rect()
-			ssidlabelelement.right = 300
+			ssidlabelelement.right = 318
 			ssidlabelelement.top = 34
 			surface.blit(renderedssidlabel, ssidlabelelement)
 
 			ssid = getcurrentssid(wlan)
-			renderedssid = font18.render(ssid, True, colors["white"], colors["darkbg"])
+			renderedssid = font_mono_small.render(ssid, True, colors["white"], colors["darkbg"])
 			ssidelement = renderedssid.get_rect()
 			ssidelement.right = 315
 			ssidelement.top = 96
 			surface.blit(renderedssid, ssidelement)
 
 			enclabel = "Key"
-			renderedenclabel = font64.render(enclabel, True, colors["lightbg"], colors["darkbg"])
+			renderedenclabel = font_huge.render(enclabel, True, colors["lightbg"], colors["darkbg"])
 			enclabelelement = renderedenclabel.get_rect()
-			enclabelelement.right = 300
+			enclabelelement.right = 314 # Drawn a bit leftwards versus "SSID" text, so both right-align pixel-perfectly
 			enclabelelement.top = 114
 			surface.blit(renderedenclabel, enclabelelement)
 
-			renderedencp = font18.render(mac, True, colors["white"], colors["darkbg"])
+			renderedencp = font_mono_small.render(mac, True, colors["white"], colors["darkbg"])
 			encpelement = renderedencp.get_rect()
 			encpelement.right = 315
 			encpelement.top = 180
@@ -1269,7 +1274,7 @@ def apinfo():
 			pygame.display.update()
 	except:
 		text = ":("
-		renderedtext = pygame.font.SysFont(None, 72).render(text, True, colors["lightbg"], colors["darkbg"])
+		renderedtext = font_huge.render(text, True, colors["lightbg"], colors["darkbg"])
 		textelement = renderedtext.get_rect()
 		textelement.left = 192
 		textelement.top = 96
@@ -1279,7 +1284,7 @@ def apinfo():
 def create_wireless_menu():
 	global wirelessmenu
 	wirelessmenu = NetworksMenu()
-	wirelessmenu.move_menu(150,40)
+	wirelessmenu.move_menu(116,40)
 
 def destroy_wireless_menu():
 	global wirelessmenu
@@ -1337,7 +1342,7 @@ def create_saved_networks_menu():
 		wirelessmenu.draw()
 	else:
 		text = 'empty'
-		renderedtext = pygame.font.SysFont(None, 72).render(text, True, colors["lightbg"], colors["darkbg"])
+		renderedtext = font_huge.render(text, True, colors["lightbg"], colors["darkbg"])
 		textelement = renderedtext.get_rect()
 		textelement.left = 152
 		textelement.top = 96
@@ -1437,7 +1442,7 @@ if __name__ == "__main__":
 							except:
 								uniq = {}
 								text = ":("
-								renderedtext = pygame.font.SysFont(None, 72).render(text, True, colors["lightbg"], colors["darkbg"])
+								renderedtext = font_huge.render(text, True, colors["lightbg"], colors["darkbg"])
 								textelement = renderedtext.get_rect()
 								textelement.left = 192
 								textelement.top = 96
@@ -1447,7 +1452,7 @@ if __name__ == "__main__":
 							l = []
 							if len(uniq) < 1:
 								text = ":("
-								renderedtext = pygame.font.SysFont(None, 72).render(text, True, colors["lightbg"], colors["darkbg"])
+								renderedtext = font_huge.render(text, True, colors["lightbg"], colors["darkbg"])
 								textelement = renderedtext.get_rect()
 								textelement.left = 192
 								textelement.top = 96


### PR DESCRIPTION
- Eliminated usage of usage of default SysFont in favor of explicitly using the DejaVuSans font included in the firmware. (Fixes legibility/appearance issues).
- Use the already-present monospaced Inconsolata.otf font for displaying ESSID/MAC/IP-address (Fixes legibility/appearance issues).
- Shifted/enlarged some interface elements  slightly to improve appearance with new fonts.
- Shifted/expanded network sub-menu, to allow display of longer ESSIDs, now that main menu takes up less space with the new font choices.
- Fonts are now all global vars.
  Fonts vars are now generically named tiny/small/medium/large/huge and their point sizes are specified in only one place.
